### PR TITLE
mednaffe: Fix segfault on shutdown

### DIFF
--- a/pkgs/misc/emulators/mednaffe/default.nix
+++ b/pkgs/misc/emulators/mednaffe/default.nix
@@ -13,7 +13,7 @@ stdenv.mkDerivation rec {
   };
 
   prePatch = ''
-    substituteInPlace src/mednaffe.c --replace "binpath = NULL" "binpath = \"${mednafen}/bin/mednafen\""
+    substituteInPlace src/mednaffe.c --replace "binpath = NULL" "binpath = g_strdup( \"${mednafen}/bin/mednafen\" )"
   '';
 
   buildInputs = [ pkgconfig gtk2 mednafen ];


### PR DESCRIPTION
###### Motivation for this change

Mednaffe leads a segfault on shutdown because expression replaces a pointer with a literal.
Fixed creating an allocated copy of literal with g_strdup() function.
###### Things done
- [ ] Tested using sandboxing
  ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS,
    or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file)
    on non-NixOS)
- Built on platform(s)
  - [ ] NixOS
  - [ ] OS X
  - [ x] Linux
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [x ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

@sheenobu
